### PR TITLE
Fix for Selenium causing intermittenly failing test

### DIFF
--- a/src/Behat/GooglePlaceAutocomplete/Contexts/GooglePlaceAutocompleteContext.php
+++ b/src/Behat/GooglePlaceAutocomplete/Contexts/GooglePlaceAutocompleteContext.php
@@ -2,6 +2,7 @@
 
 use Behat\FlexibleMink\PseudoInterface\SpinnerContextInterface;
 use Behat\Mink\Exception\ExpectationException;
+use Exception;
 use Medology\Behat\GooglePlaceAutocomplete\PseudoInterfaces\MinkContextInterface;
 
 /**
@@ -18,14 +19,16 @@ trait GooglePlaceAutocompleteContext
      */
     public function chooseFirstOption()
     {
-        $pac_first_item = $this->waitFor(function () {
-            $pac_first_item = $this->getSession()->getPage()->find('css', '.pac-container>.pac-item:first-child');
-            if (!$pac_first_item) {
-                throw new ExpectationException('Could not find the first place autocomplete item', $this->getSession());
+        $this->waitFor(function () {
+            try {
+                $pac_first_item = $this->getSession()->getPage()->find('css', '.pac-container>.pac-item:first-child');
+                if (!$pac_first_item) {
+                    throw new ExpectationException('Could not find the first place autocomplete item', $this->getSession());
+                }
+                $pac_first_item->click();
+            } catch (Exception $e) {
+                throw new ExpectationException($e->getMessage(), $this->getSession());
             }
-            return $pac_first_item;
         });
-
-        $pac_first_item->click();
     }
 }


### PR DESCRIPTION
### Problem

Autocompleted google addresses cannot be clicked sometimes due to racing conditions. Although the code had spinner for this problem, there was a flaw. Spinner looking for a link to became available, but click was happening outside of the spinner.

### Solution
Moved click action into the spinner. And the stress test passed.
