### PR TITLE
Fixing CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
           command: bin/ci-style-fixer
       - run:
           name: Merge master
-          command: git fetch origin && git merge origin/1.0 --no-edit
+          command: git fetch origin && git merge origin/master --no-edit
   test:
     description: "Set up and run tests"
     steps:


### PR DESCRIPTION
For: #56 

### Description
CircleCI is failing on this repo due to a merge conflict. 

### Cause
In CircleCI's config, we were merging with branch 1.0 instead of master. We are already on release 2.1.

### Solution
Merge with master instead.