### PR TITLE
Merge with branch 1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
             git config --global --add url.git@github.com:.insteadOf https://github.com/
       - run:
           name: Merge master
-          command: git fetch origin && git merge origin/master --no-edit
+          command: git fetch origin && git merge origin/1.0 --no-edit
   test:
     description: "Set up and run tests"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 commands:
   prep:
-    description: "Bring the repository up-to-date with master and handle setup"
+    description: "Bring the repository up-to-date with branch 1.0 and handle setup"
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
For: #56 

### Description
Builds in CircleCI were failing for PRs against the `master` branch. I was able to fix that problem with [this PR](https://github.com/Medology/behat-google-place-autocomplete/pull/60). The original problem seemed to be specific to branch `1.0` in this repository (which this PR is opened against).

### Solution
Have two separate CircleCI configurations for the branches. I considered implementing a script that would merge the appropriate branch in CircleCI depending on the tag, but this solution felt simpler. It seems there are already differences in the configs between the two branches anyway.

### Notes
Pullapprove is not set up for this specific branch, so I've requested review from Johnnie and Andrew.

View CircleCI build below for proof this PR will work.

It appears branch `1.0` is still in use in v1 of `FlexibleMink` which is used by Healthlabs.